### PR TITLE
Requirements and retry after fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ LiveODM is great for:
 ## Requirements
  * A 64-bit Computer with Ubuntu 16.04 or higher.
  * 15 GB free disk space.
- * 4GB USB Drive (USB 2.0 is fine. USB 3.0 is highly recommended. More storage space is recommended/required when using persistent mode) or an empty DVD.
+ * 8GB USB Drive (USB 2.0 is fine. USB 3.0 is highly recommended. More storage space is recommended/required when using persistent mode) or an empty DVD.
  * [Git](https://git-scm.com/downloads) if you plan on cloning this repository.
 
  Note - If you plan on Setting up a dedicated machine for ODM, the system requirements as the same as recommended for [WebODM](https://github.com/OpenDroneMap/WebODM)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ LiveODM is great for:
  
 ## Requirements
  * A 64-bit Computer with Ubuntu 16.04 or higher.
- * 10 GB free disk space.
+ * 15 GB free disk space.
  * 4GB USB Drive (USB 2.0 is fine. USB 3.0 is highly recommended. More storage space is recommended/required when using persistent mode) or an empty DVD.
  * [Git](https://git-scm.com/downloads) if you plan on cloning this repository.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ LiveODM is great for:
  
 ## Requirements
  * A 64-bit Computer with Ubuntu 16.04 or higher.
+ * 10 GB free disk space.
  * 4GB USB Drive (USB 2.0 is fine. USB 3.0 is highly recommended. More storage space is recommended/required when using persistent mode) or an empty DVD.
  * [Git](https://git-scm.com/downloads) if you plan on cloning this repository.
 

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -14,9 +14,9 @@ fi
 
 # Clean any previous failed execution.
 set +e
-mountpoint /home/andres/LiveODM/opendronemap.iso > /dev/null
+mountpoint ./opendronemap.iso > /dev/null
 if [ ${?} -eq 0 ] ; then
-	sudo umount /home/andres/LiveODM/opendronemap.iso 2> /dev/null
+	sudo umount ./opendronemap.iso 2> /dev/null
 fi
 set -e
 sudo rm -Rf mnt/ image/ squashfs-root/ 

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -13,8 +13,13 @@ if [ ! -e ./opendronemap.iso ]; then
 fi
 
 # Clean any previous failed execution.
-sudo umount /home/andres/LiveODM/opendronemap.iso 2> /dev/null
-sudo rm -Rf mnt/ image/ squashfs-root/
+set +e
+mountpoint /home/andres/LiveODM/opendronemap.iso > /dev/null
+if [ ${?} -eq 0 ] ; then
+	sudo umount /home/andres/LiveODM/opendronemap.iso 2> /dev/null
+fi
+set -e
+sudo rm -Rf mnt/ image/ squashfs-root/ 
 
 if [ ! -e ./chroot ]; then
 	mkdir mnt

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -12,6 +12,10 @@ if [ ! -e ./opendronemap.iso ]; then
 	./gdown.pl "https://drive.google.com/file/d/$GOOGLE_DRIVE_FILE_ID/edit" opendronemap.iso
 fi
 
+# Clean any previous failed execution.
+sudo umount /home/andres/LiveODM/opendronemap.iso 2> /dev/null
+sudo rm -Rf mnt/ image/ squashfs-root/
+
 if [ ! -e ./chroot ]; then
 	mkdir mnt
 	sudo mount -o loop *.iso mnt


### PR DESCRIPTION
The requirements were more specified. For example, a just 4GB USB drive is not enough; it need 4.06 GB USB drive.
Also, the space disk is important, because the ISO plus the extract makes almost 12 GB, and when using a VM create the USB drive this is important.

Because when trying multiple times, the script should restart everything and not fail because some directories were already created.